### PR TITLE
DeprecationWarning issue fixed

### DIFF
--- a/src/part_4/Part4.py
+++ b/src/part_4/Part4.py
@@ -14,7 +14,7 @@ X = iris.data  # features
 y = iris.target  # labels
 
 # partition into training and testing sets
-from sklearn.cross_validation import train_test_split
+from sklearn.model_selection import train_test_split
 
 # test_size=0.5 -> split in half
 X_train, X_test, y_train, y_test = train_test_split(X, y, test_size=0.5)


### PR DESCRIPTION
/anaconda/lib/python3.6/site-packages/sklearn/cross_validation.py:41: DeprecationWarning: This module was deprecated in version 0.18 in favor of the model_selection module into which all the refactored classes and functions are moved. Also note that the interface of the new CV iterators are different from that of this module. This module will be removed in 0.20.
  "This module will be removed in 0.20.", DeprecationWarning)